### PR TITLE
fix: null return type in padding generator

### DIFF
--- a/lib/src/data/generators/reference_generators/padding_generator.dart
+++ b/lib/src/data/generators/reference_generators/padding_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:figmage/src/data/generators/reference_generators/reference_theme_class_generator.dart';
+import 'package:figmage/src/data/generators/theme_extension_generators/mode_theme_extension_generator.dart';
 import 'package:figmage/src/data/util/converters/string_dart_conversion_x.dart';
 
 /// {@template padding_generator}
@@ -29,7 +30,9 @@ class PaddingGenerator extends ReferenceThemeClassGenerator {
           (m) {
             m
               ..name = '$valueFieldName${type.name.toTitleCase()}'
-              ..returns = _edgeInsetsReference
+              ..returns = isNullable
+                  ? _edgeInsetsReference.toNullable
+                  : _edgeInsetsReference
               ..type = MethodType.getter
               ..lambda = true
               ..body = _getEdgeInsetsExpression(

--- a/test/src/data/generators/reference_generators/padding_generator_test.dart
+++ b/test/src/data/generators/reference_generators/padding_generator_test.dart
@@ -119,16 +119,16 @@ class WebPadding {
         bottom: myNumbers.m,
       );
 
-  EdgeInsets get lLeft =>
+  EdgeInsets? get lLeft =>
       myNumbers.l == null ? null : EdgeInsets.only(left: myNumbers.l!);
 
-  EdgeInsets get lTop =>
+  EdgeInsets? get lTop =>
       myNumbers.l == null ? null : EdgeInsets.only(top: myNumbers.l!);
 
-  EdgeInsets get lRight =>
+  EdgeInsets? get lRight =>
       myNumbers.l == null ? null : EdgeInsets.only(right: myNumbers.l!);
 
-  EdgeInsets get lBottom =>
+  EdgeInsets? get lBottom =>
       myNumbers.l == null ? null : EdgeInsets.only(bottom: myNumbers.l!);
 
   EdgeInsets? get lVertical => myNumbers.l == null

--- a/test/src/data/generators/reference_generators/padding_generator_test.dart
+++ b/test/src/data/generators/reference_generators/padding_generator_test.dart
@@ -131,21 +131,21 @@ class WebPadding {
   EdgeInsets get lBottom =>
       myNumbers.l == null ? null : EdgeInsets.only(bottom: myNumbers.l!);
 
-  EdgeInsets get lVertical => myNumbers.l == null
+  EdgeInsets? get lVertical => myNumbers.l == null
       ? null
       : EdgeInsets.only(
           top: myNumbers.l!,
           bottom: myNumbers.l!,
         );
 
-  EdgeInsets get lHorizontal => myNumbers.l == null
+  EdgeInsets? get lHorizontal => myNumbers.l == null
       ? null
       : EdgeInsets.only(
           left: myNumbers.l!,
           right: myNumbers.l!,
         );
 
-  EdgeInsets get lAll => myNumbers.l == null
+  EdgeInsets? get lAll => myNumbers.l == null
       ? null
       : EdgeInsets.only(
           left: myNumbers.l!,


### PR DESCRIPTION
## Description

Fixes missing null return types in padding generator

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [X] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [X] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [X] I have added tests to cover my changes
