### PR TITLE
test: added tests for figmage conversion logic

### DIFF
--- a/lib/src/data/util/converters/type_style_conversion_x.dart
+++ b/lib/src/data/util/converters/type_style_conversion_x.dart
@@ -19,7 +19,7 @@ extension TypeStyleConversionX on TypeStyle {
   /// Makes sure that the font weight is between 100 and 900 in increments of
   /// 100.
   @visibleForTesting
-  int convertFontWeight(num weight) {
+  static int convertFontWeight(num weight) {
     final incremented = (weight / 100).round() * 100;
     return switch (incremented) {
       > 900 => 900,
@@ -31,7 +31,7 @@ extension TypeStyleConversionX on TypeStyle {
   /// Converts the line height to the way Flutter expects it, relative to the
   /// font size.
   @visibleForTesting
-  double convertLineHeight(num? lineHeight, num? fontSize) {
+  static double convertLineHeight(num? lineHeight, num? fontSize) {
     if (lineHeight == null || fontSize == null) {
       return 1;
     }

--- a/test/src/data/util/converters/color_conversion_x_test.dart
+++ b/test/src/data/util/converters/color_conversion_x_test.dart
@@ -1,0 +1,39 @@
+import 'package:figma_variables_api/figma_variables_api.dart';
+import 'package:figmage/src/data/util/converters/color_conversion_x.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ColorConversionX', () {
+    group('toValue', () {
+      test('works for 50% grey', () {
+        final color = Color(r: 0.5, g: 0.5, b: 0.5, a: 0.5);
+        final result = color.toValue();
+        expect(result, 0x80808080);
+      });
+
+      test('works for white', () async {
+        final color = Color(r: 1, g: 1, b: 1, a: 1);
+        final result = color.toValue();
+        expect(result, 0xFFFFFFFF);
+      });
+
+      test('works for black', () async {
+        final color = Color(r: 0, g: 0, b: 0, a: 1);
+        final result = color.toValue();
+        expect(result, 0xFF000000);
+      });
+
+      test('works for rgb', () async {
+        final color = Color(r: 0.5, g: 0.25, b: 0.75, a: 1);
+        final result = color.toValue();
+        expect(result, 0xFF8040BF);
+      });
+
+      test('should throw an exception if the color is not valid', () {
+        final color = Color(r: 0.5, g: 0.5, b: 0.5);
+        int result() => color.toValue();
+        expect(result, throwsException);
+      });
+    });
+  });
+}

--- a/test/src/data/util/converters/type_style_conversion_x_test.dart
+++ b/test/src/data/util/converters/type_style_conversion_x_test.dart
@@ -1,0 +1,166 @@
+import 'package:figma_variables_api/figma_variables_api.dart';
+import 'package:figmage/src/data/util/converters/type_style_conversion_x.dart';
+import 'package:figmage/src/domain/models/typography/typography.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {});
+
+  group('TypeStyleConversionX', () {
+    group('toDomain', () {
+      test('should convert a type style to a typography', () {
+        final typeStyle = TypeStyle(
+          fontFamily: 'Roboto',
+          fontPostScriptName: 'Roboto-Regular',
+          fontSize: 16,
+          fontWeight: 400,
+          italic: false,
+          letterSpacing: 0,
+          lineHeightPx: 20,
+        );
+
+        final result = typeStyle.toDomain();
+
+        expect(result.fontFamily, 'Roboto');
+        expect(result.fontFamilyPostScriptName, 'Roboto-Regular');
+        expect(result.fontSize, 16);
+        expect(result.fontWeight, 400);
+        expect(result.fontStyle, FontStyle.normal);
+        expect(result.letterSpacing, 0);
+        expect(result.height, 1.25);
+      });
+
+      test('should convert a type style to a typography with italic', () {
+        final typeStyle = TypeStyle(
+          fontFamily: 'Roboto',
+          fontPostScriptName: 'Roboto-Regular',
+          fontSize: 16,
+          fontWeight: 400,
+          italic: true,
+          letterSpacing: 0,
+          lineHeightPx: 20,
+        );
+
+        final result = typeStyle.toDomain();
+
+        expect(result.fontFamily, 'Roboto');
+        expect(result.fontFamilyPostScriptName, 'Roboto-Regular');
+        expect(result.fontSize, 16);
+        expect(result.fontWeight, 400);
+        expect(result.fontStyle, FontStyle.italic);
+        expect(result.letterSpacing, 0);
+        expect(result.height, 1.25);
+      });
+
+      test('should convert a type style to a typography with no line height',
+          () {
+        final typeStyle = TypeStyle(
+          fontFamily: 'Roboto',
+          fontPostScriptName: 'Roboto-Regular',
+          fontSize: 16,
+          fontWeight: 400,
+          italic: false,
+          letterSpacing: 0,
+        );
+
+        final result = typeStyle.toDomain();
+
+        expect(result.fontFamily, 'Roboto');
+        expect(result.fontFamilyPostScriptName, 'Roboto-Regular');
+        expect(result.fontSize, 16);
+        expect(result.fontWeight, 400);
+        expect(result.fontStyle, FontStyle.normal);
+        expect(result.letterSpacing, 0);
+        expect(result.height, 1);
+      });
+
+      test('should convert a type style to a typography with no font weight',
+          () {
+        final typeStyle = TypeStyle(
+          fontFamily: 'Roboto',
+          fontPostScriptName: 'Roboto-Regular',
+          fontSize: 16,
+          italic: false,
+          letterSpacing: 0,
+          lineHeightPx: 20,
+        );
+
+        final result = typeStyle.toDomain();
+
+        expect(result.fontFamily, 'Roboto');
+        expect(result.fontFamilyPostScriptName, 'Roboto-Regular');
+        expect(result.fontSize, 16);
+        expect(result.fontWeight, 400);
+        expect(result.fontStyle, FontStyle.normal);
+        expect(result.letterSpacing, 0);
+        expect(result.height, 1.25);
+      });
+    });
+
+    group('convertFontWeight', () {
+      test('should return 100 for 0', () {
+        expect(TypeStyleConversionX.convertFontWeight(0), 100);
+      });
+
+      test('should return 100 for 100', () {
+        expect(TypeStyleConversionX.convertFontWeight(100), 100);
+      });
+
+      test('should return 200 for 200', () {
+        expect(TypeStyleConversionX.convertFontWeight(200), 200);
+      });
+
+      test('should return 300 for 300', () {
+        expect(TypeStyleConversionX.convertFontWeight(300), 300);
+      });
+
+      test('should return 400 for 400', () {
+        expect(TypeStyleConversionX.convertFontWeight(400), 400);
+      });
+
+      test('should return 500 for 500', () {
+        expect(TypeStyleConversionX.convertFontWeight(500), 500);
+      });
+
+      test('should return 600 for 600', () {
+        expect(TypeStyleConversionX.convertFontWeight(600), 600);
+      });
+
+      test('should return 700 for 700', () {
+        expect(TypeStyleConversionX.convertFontWeight(700), 700);
+      });
+
+      test('should return 800 for 800', () {
+        expect(TypeStyleConversionX.convertFontWeight(800), 800);
+      });
+
+      test('should return 900 for 900', () {
+        expect(TypeStyleConversionX.convertFontWeight(900), 900);
+      });
+
+      test('should return 900 for 1000', () {
+        expect(TypeStyleConversionX.convertFontWeight(1000), 900);
+      });
+
+      test('should round', () {
+        expect(TypeStyleConversionX.convertFontWeight(520), 500);
+        expect(TypeStyleConversionX.convertFontWeight(549), 500);
+        expect(TypeStyleConversionX.convertFontWeight(550), 600);
+      });
+    });
+
+    group('convertLineHeight', () {
+      test('returns 1 if either are null', () async {
+        expect(TypeStyleConversionX.convertLineHeight(null, 10), 1);
+        expect(TypeStyleConversionX.convertLineHeight(10, null), 1);
+        expect(TypeStyleConversionX.convertLineHeight(null, null), 1);
+      });
+
+      test('returns relative height to font size', () async {
+        expect(TypeStyleConversionX.convertLineHeight(10, 10), 1);
+        expect(TypeStyleConversionX.convertLineHeight(20, 10), 2);
+        expect(TypeStyleConversionX.convertLineHeight(5, 10), 0.5);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

This adds tests for the conversion of Colors and TypeStyles from Figma to Flutter.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
