### PR TITLE
fix: remove `packageDir` from figmage.yaml, the package will always be generated in the directory where you put the figmage.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ dart pub global activate figmage
 
 ### 🚀 Quick start
 
+Create a folder in which you want your generated package to live. For example:
+  
+```sh
+mkdir packages/my_design_system
+cd packages/my_design_system
+```
+
 This command will generate a new package at the specified output path using the provided Figma API token and file ID:
 
 ```sh
@@ -101,20 +108,25 @@ figmage forge <path> --token <token> --fileId <fileId>
 > The **fileId** is part of the URL when you open a Figma file. Just look in your browser's address bar when you have your design system file open:
 >
 > ➡ figma.com/file/**your-file-id-is-here**/more-not-so-interesting-stuff
+>
+> or
+> 
+> ➡ figma.com/design/**your-file-id-is-here**/more-not-so-interesting-stuff
+
 
 ### 🎨 Details
 
-If you require more control over the generated code, create a `figmage.yaml` file in the directory from which you're running the command. Below is an example, along with descriptions of what each flag accomplishes:
+If you require more control over the generated code, create a `figmage.yaml` file in the directory in which you want the package to be generated. This file will then always live **next to the `pubspec.yaml`** of the generated package.
+
+Below is an example, along with descriptions of what each flag accomplishes:
 
 ```yaml
 # Default: "figmage_package". The name of the generated Dart package.
-packageName: "figmage_package"
+packageName: "my_design_system"
 # Required. The Figma file ID from which to generate tokens.
 fileId: "YOUR_FIGMA_FILE_ID"
 # Default: ''. Description of the generated package.
 packageDescription: "A package generated from Figma designs."
-# Default: '.'. Directory to generate the package in, relative to this config file.
-packageDir: "./generated"
 # Default: true. Determines whether to drop unresolvable values. When true, values that cannot be resolved (e.g., an alias pointing to a missing variable) are omitted, ensuring all tokens are resolvable in all modes (e.g., light and dark mode). When false, unresolved variables are included but will return null. Defaults to false.
 dropUnresolved: true
 colors:

--- a/lib/src/commands/shared/forge_settings_providers.dart
+++ b/lib/src/commands/shared/forge_settings_providers.dart
@@ -13,7 +13,7 @@ final settingsProvider = FutureProvider.autoDispose
     .family<FigmageSettings, ArgResults>((ref, args) async {
   final dir = switch (args['path']) {
     final String dir => Directory(dir),
-    _ => Directory.current,
+    _ => throw ArgumentError.notNull('path'),
   };
 
   final configPath = join(dir.path, 'figmage.yaml');

--- a/lib/src/commands/shared/forge_settings_providers.dart
+++ b/lib/src/commands/shared/forge_settings_providers.dart
@@ -6,17 +6,12 @@ import 'package:figmage/src/domain/providers/config_providers.dart';
 import 'package:path/path.dart';
 import 'package:riverpod/riverpod.dart';
 
-/// The arguments for the [settingsProvider] famil.
-typedef SettingsProviderArgs = ({
-  ArgResults argResults,
-});
-
 /// Tries to parse the shared settings that are needed for the `forge` command.
 ///
 /// Throws an error if any aren't present.
 final settingsProvider = FutureProvider.autoDispose
-    .family<FigmageSettings, SettingsProviderArgs>((ref, args) async {
-  final dir = switch (args.argResults['path']) {
+    .family<FigmageSettings, ArgResults>((ref, args) async {
+  final dir = switch (args['path']) {
     final String dir => Directory(dir),
     _ => Directory.current,
   };
@@ -24,21 +19,17 @@ final settingsProvider = FutureProvider.autoDispose
   final configPath = join(dir.path, 'figmage.yaml');
 
   final config = await ref.watch(configProvider(configPath).future);
-  final argResults = args.argResults;
 
   return (
-    token: switch (argResults['token']) {
+    token: switch (args['token']) {
       final String token => token,
       _ => throw ArgumentError.notNull('token'),
     },
-    fileId: switch (argResults['fileId'] ?? config.fileId) {
+    fileId: switch (args['fileId'] ?? config.fileId) {
       final String fileId => fileId,
       _ => throw ArgumentError.notNull('fileId'),
     },
-    path: switch (argResults['path']) {
-      final String path => path,
-      _ => throw ArgumentError.notNull('path'),
-    },
+    path: dir.path,
     config: config,
   );
 });

--- a/lib/src/commands/shared/generation_notifier.dart
+++ b/lib/src/commands/shared/generation_notifier.dart
@@ -29,7 +29,7 @@ class GenerationNotifier
     final FigmageSettings settings;
 
     try {
-      settings = await ref.watch(settingsProvider((argResults: arg)).future);
+      settings = await ref.watch(settingsProvider(arg).future);
     } catch (e) {
       logger.err("Not all settings are present ($e)");
       rethrow;

--- a/lib/src/domain/models/config/config.dart
+++ b/lib/src/domain/models/config/config.dart
@@ -29,7 +29,6 @@ class Config with EquatableMixin {
     this.packageName = "figmage_package",
     this.fileId,
     this.packageDescription = '',
-    this.packageDir = '.',
     this.dropUnresolved = false,
     this.colors = const GenerationSettings(),
     this.typography = const TypographyGenerationSettings(),
@@ -59,12 +58,6 @@ class Config with EquatableMixin {
   /// dark mode). When false, unresolved variables are included but will return
   /// null. Defaults to false.
   final bool dropUnresolved;
-
-  /// The directory to generate the package in, relative to the config file.
-  ///
-  /// Defaults to the current directory.
-  @JsonKey(name: 'outputPath')
-  final String packageDir;
 
   /// Color generation settings, defaults to generating color tokens from
   /// all paths.
@@ -113,7 +106,6 @@ class Config with EquatableMixin {
         fileId,
         packageName,
         packageDescription,
-        packageDir,
         colors,
         typography,
         strings,

--- a/lib/src/domain/models/config/config.g.dart
+++ b/lib/src/domain/models/config/config.g.dart
@@ -16,7 +16,6 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
           fileId: $checkedConvert('fileId', (v) => v as String?),
           packageDescription:
               $checkedConvert('packageDescription', (v) => v as String? ?? ''),
-          packageDir: $checkedConvert('outputPath', (v) => v as String? ?? '.'),
           dropUnresolved:
               $checkedConvert('dropUnresolved', (v) => v as bool? ?? false),
           colors: $checkedConvert(
@@ -62,7 +61,6 @@ Config _$ConfigFromJson(Map json) => $checkedCreate(
         );
         return val;
       },
-      fieldKeyMap: const {'packageDir': 'outputPath'},
     );
 
 Map<String, dynamic> _$ConfigToJson(Config instance) => <String, dynamic>{
@@ -70,7 +68,6 @@ Map<String, dynamic> _$ConfigToJson(Config instance) => <String, dynamic>{
       'fileId': instance.fileId,
       'packageDescription': instance.packageDescription,
       'dropUnresolved': instance.dropUnresolved,
-      'outputPath': instance.packageDir,
       'colors': instance.colors.toJson(),
       'typography': instance.typography.toJson(),
       'strings': instance.strings.toJson(),

--- a/test/src/commands/forge/forge_command_test.dart
+++ b/test/src/commands/forge/forge_command_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:figma_variables_api/figma_variables_api.dart';
 import 'package:figmage/src/command_runner.dart';
+import 'package:figmage/src/commands/forge/forge_command.dart';
 import 'package:figmage/src/data/repositories/figma_variables_repository.dart';
 import 'package:figmage/src/domain/models/variable/alias_or/alias_or.dart';
 import 'package:figmage/src/domain/models/variable/variable.dart';
@@ -109,7 +110,28 @@ void main() {
       verify(
         () => logger.err('Could not find an option or flag "-p".'),
       ).called(1);
+      verify(() => logger.info('')).called(1);
+      final infoLog = verify(() => logger.info(captureAny())).captured.first;
+      expect(infoLog, usage);
       expect(exitCode, equals(ExitCode.usage.code));
+    });
+
+    test('parses args correctly', () async {
+      final command = ForgeCommand(container);
+      final args = command.argParser.parse(['-t', 'token', '-f', 'fileId']);
+      expect(args['token'], 'token');
+      expect(args['fileId'], 'fileId');
+      expect(args['path'], '.', reason: 'defaults to "."');
     });
   });
 }
+
+const usage = '''
+Usage: figmage forge [arguments]
+-h, --help                 Print this usage information.
+    --path                 The ouptut path for the generated package, if not provided, the current directory will be used.
+                           (defaults to ".")
+-t, --token (mandatory)    Your figma API token
+-f, --fileId               Your figma file ID, needs to be either given here, or in the figmage.yaml
+
+Run "figmage help" to see global options.''';

--- a/test/src/commands/shared/forge_settings_providers_test.dart
+++ b/test/src/commands/shared/forge_settings_providers_test.dart
@@ -27,52 +27,42 @@ void main() {
       when(() => argResults['token']).thenReturn("arg_token");
       when(() => argResults['fileId']).thenReturn("arg_fileId");
       when(() => argResults['path']).thenReturn("arg_path");
+      when(() => argResults.wasParsed('path')).thenReturn(true);
     });
 
     group('settingsProvider', () {
       test('returns token from argResults', () async {
-        final result = await container
-            .read(settingsProvider((argResults: argResults)).future);
+        final result =
+            await container.read(settingsProvider(argResults).future);
         expect(result.token, "arg_token");
       });
 
       test('prefers fileId from argResults', () async {
-        final result = await container
-            .read(settingsProvider((argResults: argResults)).future);
+        final result =
+            await container.read(settingsProvider(argResults).future);
         expect(result.fileId, "arg_fileId");
       });
 
       test('takes fileId from config if not in args', () async {
         when(() => argResults['fileId']).thenReturn(null);
-        final result = await container
-            .read(settingsProvider((argResults: argResults)).future);
+        final result =
+            await container.read(settingsProvider(argResults).future);
         expect(result.fileId, config.fileId);
       });
 
-      test('returns path from argResults', () async {
-        final result = await container
-            .read(settingsProvider((argResults: argResults)).future);
+      test('returns path from argResults if parsed', () async {
+        final result =
+            await container.read(settingsProvider(argResults).future);
+
         expect(result.path, "arg_path");
       });
 
       test('throws ArgumentError if token is missing', () async {
         when(() => argResults['token']).thenReturn(null);
         await expectLater(
-          () =>
-              container.read(settingsProvider((argResults: argResults)).future),
+          () => container.read(settingsProvider(argResults).future),
           throwsA(
             isA<ArgumentError>().having((p0) => p0.name, 'name', 'token'),
-          ),
-        );
-      });
-
-      test('throws ArgumentError if path is missing', () async {
-        when(() => argResults['path']).thenReturn(null);
-        await expectLater(
-          () =>
-              container.read(settingsProvider((argResults: argResults)).future),
-          throwsA(
-            isA<ArgumentError>().having((p0) => p0.name, 'name', 'path'),
           ),
         );
       });

--- a/test/src/commands/shared/forge_settings_providers_test.dart
+++ b/test/src/commands/shared/forge_settings_providers_test.dart
@@ -15,7 +15,7 @@ void main() {
     late ProviderContainer container;
     const config = Config(fileId: "fileId", packageName: "packageName");
 
-    late _MockArgResults argResults;
+    late ArgResults argResults;
     setUp(() {
       container = createContainer(
         overrides: [
@@ -53,8 +53,17 @@ void main() {
       test('returns path from argResults if parsed', () async {
         final result =
             await container.read(settingsProvider(argResults).future);
-
         expect(result.path, "arg_path");
+      });
+
+      test('throws an ArgumentError if path is not in the args', () async {
+        when(() => argResults['path']).thenReturn(null);
+        await expectLater(
+          () => container.read(settingsProvider(argResults).future),
+          throwsA(
+            isA<ArgumentError>().having((p0) => p0.name, 'name', 'path'),
+          ),
+        );
       });
 
       test('throws ArgumentError if token is missing', () async {

--- a/test/src/data/repositories/yaml_config_repository_test.dart
+++ b/test/src/data/repositories/yaml_config_repository_test.dart
@@ -81,7 +81,6 @@ void main() {
           config.packageDescription,
           'Design Tokens generated from our Figma',
         );
-        expect(config.packageDir, './path');
 
         expect(config.colors.generate, true);
         expect(config.colors.from, ['color', 'color2']);

--- a/test/src/domain/models/config/config_test.dart
+++ b/test/src/domain/models/config/config_test.dart
@@ -17,7 +17,6 @@ void main() {
       full = {
         ...minimal,
         "packageDescription": "packageDescription",
-        "outputPath": "outputPath",
         "dropUnresolved": false,
         "colors": {
           "generate": true,
@@ -58,7 +57,6 @@ void main() {
         fileId: "fileId",
         packageName: "packageName",
         packageDescription: "packageDescription",
-        packageDir: "outputPath",
         colors: GenerationSettings(
           from: ["path1", "path2"],
         ),


### PR DESCRIPTION
## Description

Fixes #118

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
