### PR TITLE
fix: correctly fetch opacity for color styles

### DIFF
--- a/integration_test/generation_notifier_integration_test.dart
+++ b/integration_test/generation_notifier_integration_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:figmage/src/command_runner.dart';
 import 'package:figmage/src/commands/shared/forge_settings_providers.dart';
 import 'package:figmage/src/domain/models/config/config.dart';
+import 'package:figmage/src/domain/models/style/design_style.dart';
 import 'package:figmage/src/domain/providers/config_providers.dart';
 import 'package:figmage/src/domain/providers/design_token_providers.dart';
 import 'package:figmage/src/domain/providers/logger_providers.dart';
@@ -85,6 +86,40 @@ void main() {
         },
       );
 
+      test(
+        'should generate correct color styles',
+        () async {
+          await runner.run(args);
+
+          final argResults = runner.parse(args).command!;
+          final settings =
+              await container.read(settingsProvider(argResults).future);
+          final styles = await container.read(stylesProvider(settings).future);
+
+          expect(
+            styles,
+            containsAll(
+              const [
+                ColorDesignStyle(
+                  id: '1:6',
+                  fullName: 'primitives/red/50',
+                  value: 0xFFFF0000,
+                ),
+                ColorDesignStyle(
+                  id: '1:8',
+                  fullName: 'primitives/green/50',
+                  value: 0xFF00FF00,
+                ),
+                ColorDesignStyle(
+                  id: '1:11',
+                  fullName: 'primitives/blue/50',
+                  value: 0x800000FF,
+                ),
+              ],
+            ),
+          );
+        },
+      );
       test('generates package name from directory by default', () async {
         await runner.run(args);
         final pubspec = File("${testDirectory.path}/pubspec.yaml");

--- a/lib/src/data/repositories/figma_styles_repository.dart
+++ b/lib/src/data/repositories/figma_styles_repository.dart
@@ -93,9 +93,18 @@ class FigmaStylesRepository implements StylesRepository {
       Rectangle(
         :final id,
         :final name?,
-        fills: [Paint(:final color?), ...],
+        fills: [Paint(:final color?, :final opacity), ...],
       ) =>
-        ColorDesignStyle(id: id, fullName: name, value: color.toValue()),
+        ColorDesignStyle(
+          id: id,
+          fullName: name,
+          value: Color(
+            a: (color.a ?? 1) * (opacity ?? 1),
+            r: color.r,
+            g: color.g,
+            b: color.b,
+          ).toValue(),
+        ),
       _ => null,
     } as DesignStyle<dynamic>?;
   }


### PR DESCRIPTION
## Description

Fixes: #172 

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
