### PR TITLE
test: fix integration tests for CI and improve their execution

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -6,12 +6,12 @@ concurrency:
 
 on:
   pull_request_target: 
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
     integration_test:
         name: Run Integration Tests
-        if: github.event.label.name == 'integration test'
+        if: contains(github.event.pull_request.labels.*.name, 'integration test')
         timeout-minutes: 10
         runs-on: ubuntu-latest
         steps:
@@ -29,9 +29,17 @@ jobs:
         - name: Ⓜ️ Set up Melos
           uses: bluefireteam/melos-action@ec2c512a52c2f359186ca19bac0be977c44913e6
         
-        - name: 🧪 Run Integration Tests
+        - name: 🧪 Run Generation Notifier Integration Test
           env:
             FIGMA_FREE_TOKEN: ${{ secrets.FIGMA_FREE_TOKEN }}
-          run: |
-            dart test integration_test/generation_notifier_integration_test.dart
-            dart test integration_test/full_integration_test.dart
+          run: dart test integration_test/generation_notifier_integration_test.dart
+
+        - name: 🧪 Run Full Integration Test
+          env:
+            FIGMA_FREE_TOKEN: ${{ secrets.FIGMA_FREE_TOKEN }}
+          run: dart test integration_test/full_integration_test.dart
+
+        - name: 🧪 Run Asset Download Integration Test
+          env:
+            FIGMA_FREE_TOKEN: ${{ secrets.FIGMA_FREE_TOKEN }}
+          run: dart test integration_test/asset_download_integration_test.dart

--- a/integration_test/asset_download_integration_test.dart
+++ b/integration_test/asset_download_integration_test.dart
@@ -4,13 +4,17 @@ import 'package:figmage/src/command_runner.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:test/test.dart';
 
+import 'util/util.dart';
+
 void main() {
   group('Asset download integration test', () {
+    final (:token, :skipMessage) = getTokenOrSkip();
+
     test(
       'downloads and generates assets from figma with config',
+      skip: skipMessage,
       () async {
-        final dir = Directory('./asset_test_package')..createSync();
-        addTearDown(() => dir.deleteSync(recursive: true));
+        final dir = createFigmageTestDirectory();
 
         // Create figmage.yaml with asset configuration
         File('${dir.path}/figmage.yaml').writeAsStringSync('''
@@ -39,7 +43,7 @@ assets:
         final exitCode = await commandRunner.run([
           'forge',
           '-t',
-          Platform.environment['FIGMA_FREE_TOKEN']!,
+          token!,
           '-p',
           dir.path,
         ]);
@@ -93,9 +97,7 @@ assets:
           reason: 'Assets class missing iconTwo constant',
         );
       },
-      timeout: const Timeout(
-        Duration(minutes: 1),
-      ),
+      timeout: const Timeout(Duration(minutes: 1)),
     );
   });
 }

--- a/integration_test/util/util.dart
+++ b/integration_test/util/util.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mason_logger/mason_logger.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+final logger = Logger();
+
+/// Tries to get the Figma token from the environment variables.
+///
+/// If the token is not found, the test is skipped and null is returned,
+/// together with a skip message.
+({String? token, String? skipMessage}) getTokenOrSkip() {
+  final figmaToken = Platform.environment['FIGMA_FREE_TOKEN'] ??
+      Platform.environment['FIGMA_TOKEN'];
+
+  if (figmaToken == null) {
+    return (
+      token: null,
+      skipMessage: 'No Figma token found in environment variables. '
+          'Set FIGMA_FREE_TOKEN or FIGMA_TOKEN to run this test.',
+    );
+  }
+
+  return (
+    token: figmaToken,
+    skipMessage: null,
+  );
+}
+
+/// Creates a temporary directory for running figmage tests.
+///
+/// This function creates a temporary directory and adds a tear-down function
+/// to delete it when the test is finished.
+///
+/// Returns the created directory.
+Directory createFigmageTestDirectory() {
+  final testDir =
+      Directory.systemTemp.createTempSync('figmage_integration_test_');
+  addTearDown(() {
+    try {
+      testDir.deleteSync(recursive: true);
+    } catch (e) {
+      logger.warn('Warning: Failed to clean up test directory: $e');
+    }
+  });
+
+  return testDir;
+}
+
+/// Runs the figmage executable with the given arguments.
+///
+/// If [attachLogger] is true, the process's stdout and stderr will be attached
+/// to the logger.
+///
+/// If [workingDirectory] is provided, the process will be run in the given
+/// directory.
+/// Otherwise, the process will be run in the current directory.
+Future<Process> runFigmage(
+  List<String> args, {
+  Directory? workingDirectory,
+  bool attachLogger = false,
+}) async {
+  // Find the executable path relative to the current file
+  final testDir = Directory.current.path;
+  var executablePath =
+      path.normalize(path.join(testDir, 'bin', 'figmage.dart'));
+  if (!File(executablePath).existsSync()) {
+    // Try relative path as fallback
+    executablePath =
+        path.normalize(path.join(testDir, '..', 'bin', 'figmage.dart'));
+  }
+
+  final process = await Process.start(
+    'dart',
+    [
+      'run',
+      executablePath,
+      ...args,
+    ],
+    workingDirectory: workingDirectory?.path,
+  );
+
+  if (attachLogger) {
+    process.stdout.transform(utf8.decoder).listen(logger.info);
+    process.stderr.transform(utf8.decoder).listen(logger.err);
+  }
+
+  return process;
+}


### PR DESCRIPTION
## Description

1. Fix integration Test runs on CI by using a temporary system directory
2. Add Asset download test to integration tests on CI run
3. Run them whenever a PR is labeled, **and** a labeled PR is updated
4. Skip integration tests when there is no token in environment instead of failing
5. Share more code between tests

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
