### PR TITLE
feat: allow for specifying an interface for generated `ThemeExtension`s to inherit

### DIFF
--- a/integration_test/generation_notifier_integration_test.dart
+++ b/integration_test/generation_notifier_integration_test.dart
@@ -300,7 +300,7 @@ void main() {
                 interfaces: [
                   InterfaceSettings(name: 'Tokens', import: 'tokens.dart'),
                 ],
-              )
+              ),
             ],
           ),
         );

--- a/integration_test/generation_notifier_integration_test.dart
+++ b/integration_test/generation_notifier_integration_test.dart
@@ -289,6 +289,40 @@ void main() {
         );
         expect(colorsFile.existsSync(), true);
       });
+
+      test('generates interface implements if wanted', () async {
+        config = const Config(
+          packageName: "test_package",
+          tokenPath: "custom/path/to/tokens",
+          colors: GenerationSettings(
+            implements: [
+              ImplementsSettings(
+                interfaces: [
+                  InterfaceSettings(name: 'Tokens', import: 'tokens.dart'),
+                ],
+              )
+            ],
+          ),
+        );
+        await runner.run(args);
+
+        final colorsFile = File(
+          "${testDirectory.path}/lib/custom/path/to/tokens/colors.dart",
+        );
+        expect(colorsFile.existsSync(), true);
+
+        final colorsFileContent = colorsFile.readAsStringSync();
+
+        expect(colorsFileContent, contains("import 'tokens.dart';"));
+        expect(
+          'class Colors'.allMatches(colorsFileContent),
+          hasLength(2),
+        );
+        expect(
+          'implements Tokens'.allMatches(colorsFileContent),
+          hasLength(2),
+        );
+      });
     });
   });
 }

--- a/lib/src/data/generators/file_generators/base_file_generator.dart
+++ b/lib/src/data/generators/file_generators/base_file_generator.dart
@@ -68,6 +68,7 @@ abstract class BaseFileGenerator<T> implements DesignTokenFileGenerator<T> {
   ThemeClassGenerator buildGeneratorForCollection({
     required String collectionName,
     required Iterable<DesignToken<T>> collectionTokens,
+    required Iterable<InterfaceSettings> interfaces,
   });
 
   Iterable<ThemeClassGenerator> get _generators sync* {
@@ -85,6 +86,7 @@ abstract class BaseFileGenerator<T> implements DesignTokenFileGenerator<T> {
       yield buildGeneratorForCollection(
         collectionName: name,
         collectionTokens: value,
+        interfaces: [],
       );
     }
   }

--- a/lib/src/data/generators/file_generators/base_file_generator.dart
+++ b/lib/src/data/generators/file_generators/base_file_generator.dart
@@ -86,7 +86,7 @@ abstract class BaseFileGenerator<T> implements DesignTokenFileGenerator<T> {
       yield buildGeneratorForCollection(
         collectionName: name,
         collectionTokens: value,
-        interfaces: [],
+        interfaces: _getInterfacesForCollection(name),
       );
     }
   }
@@ -96,5 +96,17 @@ abstract class BaseFileGenerator<T> implements DesignTokenFileGenerator<T> {
     return usedNames.contains(name)
         ? '$name${usedNames.where((item) => item == name).length}'
         : name;
+  }
+
+  Iterable<InterfaceSettings> _getInterfacesForCollection(
+    String collectionName,
+  ) {
+    return implementsSettings
+        .where(
+          (s) =>
+              s.appliesToAllCollections ||
+              s.collections.contains(collectionName),
+        )
+        .expand((s) => s.interfaces);
   }
 }

--- a/lib/src/data/generators/file_generators/base_file_generator.dart
+++ b/lib/src/data/generators/file_generators/base_file_generator.dart
@@ -4,6 +4,7 @@ import 'package:figmage/src/data/generators/generator_util.dart';
 import 'package:figmage/src/data/util/converters/string_dart_conversion_x.dart';
 import 'package:figmage/src/domain/generators/file_generator.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/models/design_token.dart';
 import 'package:figmage_package_generator/figmage_package_generator.dart';
 import 'package:meta/meta.dart';
@@ -17,6 +18,7 @@ abstract class BaseFileGenerator<T> implements DesignTokenFileGenerator<T> {
   BaseFileGenerator({
     required this.type,
     required this.tokens,
+    required this.implementsSettings,
   });
 
   @override
@@ -27,6 +29,9 @@ abstract class BaseFileGenerator<T> implements DesignTokenFileGenerator<T> {
 
   @override
   late Iterable<ThemeClassGenerator> generators = _generators;
+
+  @override
+  final Iterable<ImplementsSettings> implementsSettings;
 
   /// Get the class name for a collection name of design tokens for the [type]
   /// of this generator.

--- a/lib/src/data/generators/file_generators/color_file_generator.dart
+++ b/lib/src/data/generators/file_generators/color_file_generator.dart
@@ -2,6 +2,7 @@ import 'package:figmage/src/data/generators/file_generators/base_file_generator.
 import 'package:figmage/src/data/generators/theme_extension_generators/color_theme_extension_generator.dart';
 import 'package:figmage/src/domain/generators/file_generator.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/models/design_token.dart';
 import 'package:figmage/src/domain/util/token_filter_x.dart';
 import 'package:figmage_package_generator/figmage_package_generator.dart';
@@ -22,10 +23,12 @@ class ColorFileGenerator extends BaseFileGenerator<int> {
   ThemeClassGenerator buildGeneratorForCollection({
     required String collectionName,
     required Iterable<DesignToken<int>> collectionTokens,
+    required Iterable<InterfaceSettings> interfaces,
   }) {
     return ColorThemeExtensionGenerator(
       className: getClassNameForCollection(collectionName),
       valuesByNameByMode: collectionTokens.valuesByNameByMode,
+      interfaces: interfaces,
     );
   }
 }

--- a/lib/src/data/generators/file_generators/color_file_generator.dart
+++ b/lib/src/data/generators/file_generators/color_file_generator.dart
@@ -15,6 +15,7 @@ class ColorFileGenerator extends BaseFileGenerator<int> {
   /// {@macro color_file_generator}
   ColorFileGenerator({
     required super.tokens,
+    required super.implementsSettings,
   }) : super(type: TokenFileType.color);
 
   @override

--- a/lib/src/data/generators/file_generators/number_file_generator.dart
+++ b/lib/src/data/generators/file_generators/number_file_generator.dart
@@ -15,6 +15,7 @@ class NumberFileGenerator extends BaseFileGenerator<double> {
   /// {@macro number_file_generator}
   NumberFileGenerator({
     required super.tokens,
+    required super.implementsSettings,
   }) : super(type: TokenFileType.numbers);
 
   @override

--- a/lib/src/data/generators/file_generators/number_file_generator.dart
+++ b/lib/src/data/generators/file_generators/number_file_generator.dart
@@ -2,6 +2,7 @@ import 'package:figmage/src/data/generators/file_generators/base_file_generator.
 import 'package:figmage/src/data/generators/theme_extension_generators/number_theme_extension_generator.dart';
 import 'package:figmage/src/domain/generators/file_generator.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/models/design_token.dart';
 import 'package:figmage/src/domain/util/token_filter_x.dart';
 import 'package:figmage_package_generator/figmage_package_generator.dart';
@@ -22,10 +23,12 @@ class NumberFileGenerator extends BaseFileGenerator<double> {
   ThemeClassGenerator buildGeneratorForCollection({
     required String collectionName,
     required Iterable<DesignToken<double>> collectionTokens,
+    required Iterable<InterfaceSettings> interfaces,
   }) {
     return NumberThemeExtensionGenerator(
       className: getClassNameForCollection(collectionName),
       valuesByNameByMode: collectionTokens.valuesByNameByMode,
+      interfaces: interfaces,
     );
   }
 }

--- a/lib/src/data/generators/file_generators/padding_file_generator.dart
+++ b/lib/src/data/generators/file_generators/padding_file_generator.dart
@@ -16,6 +16,7 @@ class PaddingFileGenerator extends BaseFileGenerator<double> {
   /// {@macro padding_file_generator}
   PaddingFileGenerator({
     required super.tokens,
+    required super.implementsSettings,
   }) : super(type: TokenFileType.paddings);
 
   @override

--- a/lib/src/data/generators/file_generators/padding_file_generator.dart
+++ b/lib/src/data/generators/file_generators/padding_file_generator.dart
@@ -3,6 +3,7 @@ import 'package:figmage/src/data/generators/file_generators/base_file_generator.
 import 'package:figmage/src/data/generators/reference_generators/padding_generator.dart';
 import 'package:figmage/src/domain/generators/file_generator.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/models/design_token.dart';
 import 'package:figmage/src/domain/util/token_filter_x.dart';
 import 'package:figmage_package_generator/figmage_package_generator.dart';
@@ -23,6 +24,7 @@ class PaddingFileGenerator extends BaseFileGenerator<double> {
   ThemeClassGenerator buildGeneratorForCollection({
     required String collectionName,
     required Iterable<DesignToken<double>> collectionTokens,
+    required Iterable<InterfaceSettings> interfaces,
   }) {
     return PaddingGenerator(
       className: getClassNameForCollection(collectionName),

--- a/lib/src/data/generators/file_generators/spacer_file_generator.dart
+++ b/lib/src/data/generators/file_generators/spacer_file_generator.dart
@@ -16,6 +16,7 @@ class SpacerFileGenerator extends BaseFileGenerator<double> {
   /// {@macro spacer_file_generator}
   SpacerFileGenerator({
     required super.tokens,
+    required super.implementsSettings,
   }) : super(type: TokenFileType.spacers);
 
   @override

--- a/lib/src/data/generators/file_generators/spacer_file_generator.dart
+++ b/lib/src/data/generators/file_generators/spacer_file_generator.dart
@@ -3,6 +3,7 @@ import 'package:figmage/src/data/generators/file_generators/base_file_generator.
 import 'package:figmage/src/data/generators/reference_generators/spacer_generator.dart';
 import 'package:figmage/src/domain/generators/file_generator.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/models/design_token.dart';
 import 'package:figmage/src/domain/util/token_filter_x.dart';
 import 'package:figmage_package_generator/figmage_package_generator.dart';
@@ -23,6 +24,7 @@ class SpacerFileGenerator extends BaseFileGenerator<double> {
   ThemeClassGenerator buildGeneratorForCollection({
     required String collectionName,
     required Iterable<DesignToken<double>> collectionTokens,
+    required Iterable<InterfaceSettings> interfaces,
   }) {
     return SpacerGenerator(
       className: getClassNameForCollection(collectionName),

--- a/lib/src/data/generators/file_generators/typography_file_generator.dart
+++ b/lib/src/data/generators/file_generators/typography_file_generator.dart
@@ -17,6 +17,7 @@ class TypographyFileGenerator extends BaseFileGenerator<Typography> {
   TypographyFileGenerator({
     required super.tokens,
     required this.useGoogleFonts,
+    required super.implementsSettings,
   }) : super(type: TokenFileType.typography);
 
   /// Whether to use Google Fonts in the generated theme extensions.

--- a/lib/src/data/generators/file_generators/typography_file_generator.dart
+++ b/lib/src/data/generators/file_generators/typography_file_generator.dart
@@ -2,6 +2,7 @@ import 'package:figmage/src/data/generators/file_generators/base_file_generator.
 import 'package:figmage/src/data/generators/theme_extension_generators/text_style_theme_extension_generator.dart';
 import 'package:figmage/src/domain/generators/file_generator.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/models/design_token.dart';
 import 'package:figmage/src/domain/models/typography/typography.dart';
 import 'package:figmage/src/domain/util/token_filter_x.dart';
@@ -27,11 +28,13 @@ class TypographyFileGenerator extends BaseFileGenerator<Typography> {
   ThemeClassGenerator buildGeneratorForCollection({
     required String collectionName,
     required Iterable<DesignToken<Typography>> collectionTokens,
+    required Iterable<InterfaceSettings> interfaces,
   }) {
     return TextStyleThemeExtensionGenerator(
       className: getClassNameForCollection(collectionName),
       valuesByNameByMode: collectionTokens.valuesByNameByMode,
       useGoogleFonts: useGoogleFonts,
+      interfaces: interfaces,
     );
   }
 }

--- a/lib/src/data/generators/theme_extension_generators/color_theme_extension_generator.dart
+++ b/lib/src/data/generators/theme_extension_generators/color_theme_extension_generator.dart
@@ -14,6 +14,7 @@ class ColorThemeExtensionGenerator extends ModeThemeExtensionGenerator<int> {
   ColorThemeExtensionGenerator({
     required super.className,
     required super.valuesByNameByMode,
+    required super.interfaces,
     super.buildContextExtensionNullable = false,
   }) : super(
           symbolReference: _colorReference,

--- a/lib/src/data/generators/theme_extension_generators/mode_theme_extension_generator.dart
+++ b/lib/src/data/generators/theme_extension_generators/mode_theme_extension_generator.dart
@@ -129,6 +129,9 @@ abstract class ModeThemeExtensionGenerator<T>
         )
         ..extend =
             refer('ThemeExtension<$className>', 'package:flutter/material.dart')
+        ..implements.addAll([
+          for (final i in interfaces) refer(i.name, i.import),
+        ])
         ..constructors.add(_getConstructor(nameList: parameterNames))
         ..constructors.addAll(_getNamedConstructors(valueMaps: valueMaps))
         ..fields.addAll(

--- a/lib/src/data/generators/theme_extension_generators/mode_theme_extension_generator.dart
+++ b/lib/src/data/generators/theme_extension_generators/mode_theme_extension_generator.dart
@@ -3,6 +3,7 @@ import 'dart:core';
 import 'package:code_builder/code_builder.dart';
 import 'package:figmage/src/data/generators/generator_util.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/util/values_by_name_by_mode_x.dart';
 
 /// {@template theme_extension_generator}
@@ -36,6 +37,7 @@ abstract class ModeThemeExtensionGenerator<T>
     required String className,
     required this.valuesByNameByMode,
     required this.symbolReference,
+    required this.interfaces,
     this.buildContextExtensionNullable = false,
     this.lerpReference,
   })  : className = convertToValidClassName(className),
@@ -52,6 +54,9 @@ abstract class ModeThemeExtensionGenerator<T>
 
   @override
   final bool buildContextExtensionNullable;
+
+  @override
+  final Iterable<InterfaceSettings> interfaces;
 
   /// A map with the following structure: <ModeName<ValueName, Value>>
   ///

--- a/lib/src/data/generators/theme_extension_generators/number_theme_extension_generator.dart
+++ b/lib/src/data/generators/theme_extension_generators/number_theme_extension_generator.dart
@@ -10,6 +10,7 @@ class NumberThemeExtensionGenerator
   NumberThemeExtensionGenerator({
     required super.className,
     required super.valuesByNameByMode,
+    required super.interfaces,
     super.buildContextExtensionNullable = false,
   }) : super(
           symbolReference: const Reference('double'),

--- a/lib/src/data/generators/theme_extension_generators/text_style_theme_extension_generator.dart
+++ b/lib/src/data/generators/theme_extension_generators/text_style_theme_extension_generator.dart
@@ -24,6 +24,7 @@ class TextStyleThemeExtensionGenerator
     required super.className,
     required super.valuesByNameByMode,
     required this.useGoogleFonts,
+    required super.interfaces,
     super.buildContextExtensionNullable = false,
   }) : super(symbolReference: _textStyleReference);
 

--- a/lib/src/domain/generators/file_generator.dart
+++ b/lib/src/domain/generators/file_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:figmage/src/domain/generators/theme_class_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage/src/domain/models/design_token.dart';
 import 'package:figmage_package_generator/figmage_package_generator.dart';
 
@@ -30,4 +31,8 @@ abstract interface class FileGenerator {
 abstract interface class DesignTokenFileGenerator<T> implements FileGenerator {
   /// The list of tokens that will be generated for.
   Iterable<DesignToken<T>> get tokens;
+
+  /// The settings that specify which collection should implement which
+  /// interface.
+  Iterable<ImplementsSettings> get implementsSettings;
 }

--- a/lib/src/domain/generators/theme_class_generator.dart
+++ b/lib/src/domain/generators/theme_class_generator.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 
 /// {@template generator}
 /// The superclass for all generators that can generate
@@ -36,4 +37,7 @@ abstract interface class ThemeExtensionGenerator
   /// A [Reference] to the symbol (e.g., Color, TextStyle) used in the theme
   /// extension.
   Reference get symbolReference;
+
+  /// The interfaces that the generated class should implement.
+  Iterable<InterfaceSettings> get interfaces;
 }

--- a/lib/src/domain/models/config/config.dart
+++ b/lib/src/domain/models/config/config.dart
@@ -261,6 +261,12 @@ class ImplementsSettings with EquatableMixin {
   /// The interfaces to implement in the generated code.
   final List<InterfaceSettings> interfaces;
 
+  /// Whether this setting applies to all collections, meaning that the
+  /// interfaces will be implemented in all collections, regardless of the
+  /// collection name.
+  bool get appliesToAllCollections =>
+      collections.isEmpty && interfaces.isNotEmpty;
+
   /// Converts a [ImplementsSettings] to a map.
   Map<String, dynamic> toJson() => _$ImplementsSettingsToJson(this);
 

--- a/lib/src/domain/models/config/config.dart
+++ b/lib/src/domain/models/config/config.dart
@@ -175,7 +175,8 @@ class GenerationSettings with EquatableMixin {
   /// {@macro generation_settings}
   const GenerationSettings({
     this.generate = true,
-    this.from = const <String>[],
+    this.from = const [],
+    this.implements = const [],
   });
 
   /// Initializes a [GenerationSettings] from a json map.
@@ -188,11 +189,17 @@ class GenerationSettings with EquatableMixin {
   /// The paths to generate from, defaults to empty which means all paths.
   final Iterable<String> from;
 
+  /// The implements settings for this type of token.
+  ///
+  /// By default, generated classes don't implement any interfaces, but you can
+  /// use this setting to specify a custom list of interfaces to implement.
+  final Iterable<ImplementsSettings> implements;
+
   /// Converts a [GenerationSettings] to a map.
   Map<dynamic, dynamic> toJson() => _$GenerationSettingsToJson(this);
 
   @override
-  List<Object?> get props => [generate, ...from];
+  List<Object?> get props => [generate, ...from, ...implements];
 }
 
 /// {@template typography_generation_settings}
@@ -206,6 +213,7 @@ class TypographyGenerationSettings extends GenerationSettings {
   const TypographyGenerationSettings({
     super.generate,
     super.from,
+    super.implements,
     this.useGoogleFonts = true,
   });
 
@@ -223,6 +231,72 @@ class TypographyGenerationSettings extends GenerationSettings {
 
   @override
   List<Object?> get props => [...super.props, useGoogleFonts];
+}
+
+/// {@template implements_settings}
+/// Settings for implementing interfaces in the generated code.
+///
+/// You can specify a list of [collections] for which this setting applies,
+/// as well as a list of [interfaces] to implement in the generated code.
+///
+/// {@endtemplate}
+@JsonSerializable(anyMap: true, checked: true)
+class ImplementsSettings with EquatableMixin {
+  /// {@macro implements_settings}
+  const ImplementsSettings({
+    this.collections = const [],
+    this.interfaces = const [],
+  });
+
+  /// Initializes a [ImplementsSettings] from a json map.
+  factory ImplementsSettings.fromJson(Map<String, dynamic> json) =>
+      _$ImplementsSettingsFromJson(json);
+
+  /// The paths to generate from, defaults to empty.
+  ///
+  /// If you leave this empty, but specify [interfaces], the interfaces will
+  /// apply to all collections.
+  final List<String> collections;
+
+  /// The interfaces to implement in the generated code.
+  final List<InterfaceSettings> interfaces;
+
+  /// Converts a [ImplementsSettings] to a map.
+  Map<String, dynamic> toJson() => _$ImplementsSettingsToJson(this);
+
+  @override
+  List<Object?> get props => [...collections, ...interfaces];
+}
+
+/// {@template interface_settings}
+/// Settings for a single interface to implement in the generated code.
+///
+/// This includes the name of the interface and the import directive for that
+/// interface.
+/// {@endtemplate}
+@JsonSerializable(anyMap: true, checked: true)
+class InterfaceSettings with EquatableMixin {
+  /// {@macro interface_settings}
+  const InterfaceSettings({
+    required this.name,
+    required this.import,
+  });
+
+  /// Initializes a [InterfaceSettings] from a json map.
+  factory InterfaceSettings.fromJson(Map<String, dynamic> json) =>
+      _$InterfaceSettingsFromJson(json);
+
+  /// The name of the interface to implement.
+  final String name;
+
+  /// The content of the import directive for that interface.
+  final String import;
+
+  /// Converts a [ImplementsSettings] to a map.
+  Map<String, dynamic> toJson() => _$InterfaceSettingsToJson(this);
+
+  @override
+  List<Object?> get props => [name, import];
 }
 
 /// {@template asset_node_settings}

--- a/lib/src/domain/models/config/config.g.dart
+++ b/lib/src/domain/models/config/config.g.dart
@@ -103,8 +103,13 @@ GenerationSettings _$GenerationSettingsFromJson(Map json) => $checkedCreate(
           from: $checkedConvert(
               'from',
               (v) =>
-                  (v as List<dynamic>?)?.map((e) => e as String) ??
-                  const <String>[]),
+                  (v as List<dynamic>?)?.map((e) => e as String) ?? const []),
+          implements: $checkedConvert(
+              'implements',
+              (v) =>
+                  (v as List<dynamic>?)?.map((e) => ImplementsSettings.fromJson(
+                      Map<String, dynamic>.from(e as Map))) ??
+                  const []),
         );
         return val;
       },
@@ -114,6 +119,7 @@ Map<String, dynamic> _$GenerationSettingsToJson(GenerationSettings instance) =>
     <String, dynamic>{
       'generate': instance.generate,
       'from': instance.from.toList(),
+      'implements': instance.implements.toList(),
     };
 
 TypographyGenerationSettings _$TypographyGenerationSettingsFromJson(Map json) =>
@@ -126,8 +132,13 @@ TypographyGenerationSettings _$TypographyGenerationSettingsFromJson(Map json) =>
           from: $checkedConvert(
               'from',
               (v) =>
-                  (v as List<dynamic>?)?.map((e) => e as String) ??
-                  const <String>[]),
+                  (v as List<dynamic>?)?.map((e) => e as String) ?? const []),
+          implements: $checkedConvert(
+              'implements',
+              (v) =>
+                  (v as List<dynamic>?)?.map((e) => ImplementsSettings.fromJson(
+                      Map<String, dynamic>.from(e as Map))) ??
+                  const []),
           useGoogleFonts:
               $checkedConvert('useGoogleFonts', (v) => v as bool? ?? true),
         );
@@ -140,7 +151,55 @@ Map<String, dynamic> _$TypographyGenerationSettingsToJson(
     <String, dynamic>{
       'generate': instance.generate,
       'from': instance.from.toList(),
+      'implements': instance.implements.toList(),
       'useGoogleFonts': instance.useGoogleFonts,
+    };
+
+ImplementsSettings _$ImplementsSettingsFromJson(Map json) => $checkedCreate(
+      'ImplementsSettings',
+      json,
+      ($checkedConvert) {
+        final val = ImplementsSettings(
+          collections: $checkedConvert(
+              'collections',
+              (v) =>
+                  (v as List<dynamic>?)?.map((e) => e as String).toList() ??
+                  const []),
+          interfaces: $checkedConvert(
+              'interfaces',
+              (v) =>
+                  (v as List<dynamic>?)
+                      ?.map((e) => InterfaceSettings.fromJson(
+                          Map<String, dynamic>.from(e as Map)))
+                      .toList() ??
+                  const []),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$ImplementsSettingsToJson(ImplementsSettings instance) =>
+    <String, dynamic>{
+      'collections': instance.collections,
+      'interfaces': instance.interfaces,
+    };
+
+InterfaceSettings _$InterfaceSettingsFromJson(Map json) => $checkedCreate(
+      'InterfaceSettings',
+      json,
+      ($checkedConvert) {
+        final val = InterfaceSettings(
+          name: $checkedConvert('name', (v) => v as String),
+          import: $checkedConvert('import', (v) => v as String),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$InterfaceSettingsToJson(InterfaceSettings instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'import': instance.import,
     };
 
 AssetNodeSettings _$AssetNodeSettingsFromJson(Map json) => $checkedCreate(

--- a/lib/src/domain/providers/generator_providers.dart
+++ b/lib/src/domain/providers/generator_providers.dart
@@ -46,19 +46,24 @@ final generatorsProvider =
         file: switch (type) {
           TokenFileType.color => ColorFileGenerator(
               tokens: tokensByType.colorTokens,
+              implementsSettings: settings.config.colors.implements,
             ),
           TokenFileType.typography => TypographyFileGenerator(
               tokens: tokensByType.typographyTokens,
               useGoogleFonts: settings.config.typography.useGoogleFonts,
+              implementsSettings: settings.config.typography.implements,
             ),
           TokenFileType.numbers => NumberFileGenerator(
               tokens: tokensByType.numberTokens,
+              implementsSettings: settings.config.numbers.implements,
             ),
           TokenFileType.spacers => SpacerFileGenerator(
               tokens: tokensByType.numberTokens,
+              implementsSettings: settings.config.spacers.implements,
             ),
           TokenFileType.paddings => PaddingFileGenerator(
               tokens: tokensByType.numberTokens,
+              implementsSettings: settings.config.paddings.implements,
             ),
           TokenFileType.assets =>
             AssetFileGenerator(assets: assets, packageName: packageName),

--- a/test/src/data/generators/file_generators/base_file_generator_test.dart
+++ b/test/src/data/generators/file_generators/base_file_generator_test.dart
@@ -13,6 +13,7 @@ class _MockThemeClassGenerator extends Mock implements ThemeClassGenerator {}
 class _Generator extends BaseFileGenerator<int> with Mock {
   _Generator({
     required super.tokens,
+    required super.implementsSettings,
   }) : super(type: TokenFileType.color);
 }
 
@@ -35,6 +36,7 @@ void main() {
         mockColorDesignStyle,
         mockColorVariable,
       ],
+      implementsSettings: [],
     );
     generators = [];
 

--- a/test/src/data/generators/file_generators/base_file_generator_test.dart
+++ b/test/src/data/generators/file_generators/base_file_generator_test.dart
@@ -44,6 +44,7 @@ void main() {
       () => sut.buildGeneratorForCollection(
         collectionName: any(named: 'collectionName'),
         collectionTokens: any(named: 'collectionTokens'),
+        interfaces: any(named: 'interfaces'),
       ),
     ).thenAnswer((_) => getGenerator(generators.length));
   });
@@ -61,19 +62,15 @@ void main() {
             named: "collectionTokens",
             that: equals([mockColorDesignStyle]),
           ),
+          interfaces: [],
         ),
       );
 
       verify(
         () => sut.buildGeneratorForCollection(
-          collectionName: any(
-            named: "collectionName",
-            that: equals(mockColorVariable.collectionName),
-          ),
-          collectionTokens: any(
-            named: "collectionTokens",
-            that: equals([mockColorVariable]),
-          ),
+          collectionName: mockColorVariable.collectionName,
+          collectionTokens: [mockColorVariable],
+          interfaces: [],
         ),
       );
 

--- a/test/src/data/generators/file_generators/color_file_generator_test.dart
+++ b/test/src/data/generators/file_generators/color_file_generator_test.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:figmage/src/data/generators/file_generators/color_file_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:figmage_package_generator/figmage_package_generator.dart';
 import 'package:test/test.dart';
 
@@ -21,7 +22,26 @@ void main() {
           mockColorDesignStyle,
           mockColorVariableUnresolvable,
         ],
-        implementsSettings: [],
+        implementsSettings: [
+          const ImplementsSettings(
+            collections: ['collection1'],
+            interfaces: [
+              InterfaceSettings(
+                name: 'MyColors',
+                import: 'my_colors.dart',
+              ),
+            ],
+          ),
+          const ImplementsSettings(
+            collections: const [],
+            interfaces: [
+              InterfaceSettings(
+                name: 'Tokens',
+                import: 'tokens.dart',
+              ),
+            ],
+          ),
+        ],
       );
     });
 
@@ -44,9 +64,12 @@ const expected = """
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'my_colors.dart';
+import 'tokens.dart';
 
 @immutable
-class ColorsCollection1 extends ThemeExtension<ColorsCollection1> {
+class ColorsCollection1 extends ThemeExtension<ColorsCollection1> 
+  implements MyColors, Tokens{
   const ColorsCollection1({
     required this.colorColorName,
     required this.colorNameUnresolvable,
@@ -102,7 +125,7 @@ extension ColorsCollection1BuildContextX on BuildContext {
 }
 
 @immutable
-class ColorsColors extends ThemeExtension<ColorsColors> {
+class ColorsColors extends ThemeExtension<ColorsColors> implements Tokens {
   const ColorsColors({required this.colorName});
 
   const ColorsColors.standard() : colorName = const Color(0xffffffff);

--- a/test/src/data/generators/file_generators/color_file_generator_test.dart
+++ b/test/src/data/generators/file_generators/color_file_generator_test.dart
@@ -33,7 +33,6 @@ void main() {
             ],
           ),
           const ImplementsSettings(
-            collections: const [],
             interfaces: [
               InterfaceSettings(
                 name: 'Tokens',

--- a/test/src/data/generators/file_generators/color_file_generator_test.dart
+++ b/test/src/data/generators/file_generators/color_file_generator_test.dart
@@ -21,6 +21,7 @@ void main() {
           mockColorDesignStyle,
           mockColorVariableUnresolvable,
         ],
+        implementsSettings: [],
       );
     });
 

--- a/test/src/data/generators/file_generators/typography_file_generator_test.dart
+++ b/test/src/data/generators/file_generators/typography_file_generator_test.dart
@@ -28,6 +28,7 @@ void main() {
           ),
         ],
         useGoogleFonts: true,
+        implementsSettings: [],
       );
     });
 

--- a/test/src/data/generators/theme_extension_generators/color_theme_extension_generator_test.dart
+++ b/test/src/data/generators/theme_extension_generators/color_theme_extension_generator_test.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:figmage/src/data/generators/theme_extension_generators/color_theme_extension_generator.dart';
+import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:test/test.dart';
 
 import '../common.dart';
@@ -18,11 +19,16 @@ void main() {
     'mode2': {'color1': 0xFF111111, 'color2': null},
   };
 
+  const interfaces = [
+    InterfaceSettings(name: 'MyColors', import: 'my_colors.dart'),
+    InterfaceSettings(name: 'MyColors2', import: 'my_colors2.dart'),
+  ];
+
   test('Should create a class and non-nullable BuildContext extension', () {
     final generator = ColorThemeExtensionGenerator(
       className: 'MyColorTheme',
       valuesByNameByMode: valuesByNameByMode,
-      interfaces: [],
+      interfaces: interfaces,
     );
     expect(
       generator.generateClass(),
@@ -41,7 +47,7 @@ void main() {
       className: 'MyColorTheme',
       valuesByNameByMode: valuesByNameByMode,
       buildContextExtensionNullable: true,
-      interfaces: [],
+      interfaces: interfaces,
     );
     expect(
       generator.generateClass(),
@@ -83,7 +89,8 @@ void main() {
 
 const _expectedColorThemeExtensionClassString = '''
 @immutable
-class MyColorTheme extends ThemeExtension<MyColorTheme> {
+class MyColorTheme extends ThemeExtension<MyColorTheme> 
+  implements MyColors, MyColors2 {
   const MyColorTheme({
     required this.color1,
     required this.color2,

--- a/test/src/data/generators/theme_extension_generators/color_theme_extension_generator_test.dart
+++ b/test/src/data/generators/theme_extension_generators/color_theme_extension_generator_test.dart
@@ -22,6 +22,7 @@ void main() {
     final generator = ColorThemeExtensionGenerator(
       className: 'MyColorTheme',
       valuesByNameByMode: valuesByNameByMode,
+      interfaces: [],
     );
     expect(
       generator.generateClass(),
@@ -40,6 +41,7 @@ void main() {
       className: 'MyColorTheme',
       valuesByNameByMode: valuesByNameByMode,
       buildContextExtensionNullable: true,
+      interfaces: [],
     );
     expect(
       generator.generateClass(),
@@ -63,6 +65,7 @@ void main() {
         '': {'color1': 0xFF000000, 'color2': 0xFFFFFFFF},
       },
       buildContextExtensionNullable: true,
+      interfaces: [],
     );
     expect(
       generator.generateClass(),

--- a/test/src/data/generators/theme_extension_generators/number_theme_extension_generator_test.dart
+++ b/test/src/data/generators/theme_extension_generators/number_theme_extension_generator_test.dart
@@ -21,6 +21,7 @@ void main() {
     final generator = NumberThemeExtensionGenerator(
       className: 'MyNumbersTheme',
       valuesByNameByMode: valuesByNameByMode,
+      interfaces: [],
     );
     expect(
       generator.generateClass(),
@@ -43,6 +44,7 @@ void main() {
       className: 'MyNumbersTheme',
       valuesByNameByMode: valuesByNameByMode,
       buildContextExtensionNullable: true,
+      interfaces: [],
     );
     expect(
       generator.generateClass(),

--- a/test/src/data/generators/theme_extension_generators/text_style_theme_extension_generator_test.dart
+++ b/test/src/data/generators/theme_extension_generators/text_style_theme_extension_generator_test.dart
@@ -45,6 +45,7 @@ void main() {
       className: 'MyTextStyles',
       valuesByNameByMode: valuesByNameByMode,
       useGoogleFonts: false,
+      interfaces: [],
     );
     expect(
       generator.generateClass(),
@@ -67,6 +68,7 @@ void main() {
       valuesByNameByMode: valuesByNameByMode,
       buildContextExtensionNullable: true,
       useGoogleFonts: false,
+      interfaces: [],
     );
 
     expect(
@@ -89,6 +91,7 @@ void main() {
       className: 'MyTextStyles',
       valuesByNameByMode: valuesByNameByMode,
       useGoogleFonts: true,
+      interfaces: [],
     );
     expect(
       generator.generateClass(),

--- a/test/src/domain/models/config/config_test.dart
+++ b/test/src/domain/models/config/config_test.dart
@@ -2,6 +2,7 @@
 
 import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 void main() {
   group('Config', () {
@@ -244,5 +245,113 @@ void main() {
         expect(fullExample.toJson(), full);
       });
     });
+
+    group('when deserializing docs examples', () {
+      test('works', () async {
+        final yamlMap = loadYaml(docsYaml) as YamlMap;
+        final config = Config.fromMap(yamlMap);
+
+        expect(config, isA<Config>());
+      });
+
+      test('implements settings are correct', () async {
+        final yamlMap = loadYaml(docsYaml) as YamlMap;
+        final config = Config.fromMap(yamlMap);
+
+        expect(config.colors.implements, hasLength(1));
+        expect(
+          config.colors.implements.first.collections,
+          equals(["semantic"]),
+        );
+        expect(
+          config.colors.implements.first.interfaces,
+          hasLength(1),
+        );
+        expect(
+          config.colors.implements.first.interfaces.first.name,
+          equals("MyColors"),
+        );
+        expect(
+          config.colors.implements.first.interfaces.first.import,
+          equals("package:my_package/my_colors.dart"),
+        );
+      });
+
+      test('rfc example works', () async {
+        final yamlMap = loadYaml(rfcYaml) as YamlMap;
+        final config = Config.fromMap(yamlMap);
+
+        expect(config, isA<Config>());
+        expect(config.colors.implements, hasLength(1));
+        expect(
+          config.colors.implements.first.collections,
+          equals(["semantic"]),
+        );
+        expect(
+          config.colors.implements.first.interfaces,
+          hasLength(1),
+        );
+        expect(
+          config.colors.implements.first.interfaces.first.name,
+          equals("MyColors"),
+        );
+        expect(
+          config.colors.implements.first.interfaces.first.import,
+          equals("package:my_app/core/my_colors.dart"),
+        );
+      });
+    });
   });
 }
+
+const docsYaml = '''
+fileId: "YOUR_FIGMA_FILE_ID"
+packageName: "design_tokens"
+packageDescription: "A generated package that contains all of our design tokens"
+asPackage: true
+tokenPath: "src"
+dropUnresolved: true
+stylesFromLibrary: false
+colors:
+  generate: true # default
+  from:
+    - "semantic/colors"
+  implements:
+    - collections: ["semantic"]
+      interfaces:
+        - name: "MyColors"
+          import: "package:my_package/my_colors.dart"
+typography:
+  generate: true # default
+  from:
+    - "semantic/typography"
+  useGoogleFonts: true
+numbers:
+  generate: true # false by default
+  # omitting `from` will generate all number tokens
+spacers:
+  generate: false # false by default
+paddings:
+  generate: false # false by default
+assets:
+  generate: true # false by default
+  "1:5":  # Figma node ID
+    name: "check" # name of the asset
+    scales: [1, 2] # different scales
+  "23:1":
+    name: "example_name"
+''';
+
+const rfcYaml = '''
+fileId: "YOUR_FIGMA_FILE_ID"
+packageName: "design_tokens"
+asPackage: false
+colors:
+  from:
+    - "semantic/colors"
+  implements:
+    - collections: ["semantic"] # empty list would mean the following interface settings apply to all collections
+      interfaces:
+        - name: "MyColors"
+          import: "package:my_app/core/my_colors.dart"
+''';

--- a/test/src/domain/models/config/config_test.dart
+++ b/test/src/domain/models/config/config_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: inference_failure_on_collection_literal
+
 import 'package:figmage/src/domain/models/config/config.dart';
 import 'package:test/test.dart';
 
@@ -24,35 +26,43 @@ void main() {
         "colors": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
         },
         "typography": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
           "useGoogleFonts": false,
         },
         "strings": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
         },
         "bools": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
         },
         "numbers": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
         },
         "spacers": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
         },
         "paddings": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
         },
         "radii": {
           "generate": true,
           "from": ["path1", "path2"],
+          "implements": [],
         },
         "assets": {
           "generate": true,

--- a/test/src/domain/models/config/config_test.dart
+++ b/test/src/domain/models/config/config_test.dart
@@ -305,6 +305,7 @@ void main() {
 }
 
 const docsYaml = '''
+
 fileId: "YOUR_FIGMA_FILE_ID"
 packageName: "design_tokens"
 packageDescription: "A generated package that contains all of our design tokens"
@@ -319,8 +320,8 @@ colors:
   implements:
     - collections: ["semantic"]
       interfaces:
-        - name: "MyColors"
-          import: "package:my_package/my_colors.dart"
+      - name: "MyColors"
+        import: "package:my_package/my_colors.dart"
 typography:
   generate: true # default
   from:
@@ -337,7 +338,7 @@ assets:
   generate: true # false by default
   "1:5":  # Figma node ID
     name: "check" # name of the asset
-    scales: [1, 2] # different scales
+    scales: [1, 2] # different scales 
   "23:1":
     name: "example_name"
 ''';

--- a/tool/readme_code_generator.dart
+++ b/tool/readme_code_generator.dart
@@ -84,7 +84,10 @@ void main(List<String> args) {
     });
 
     test('colors file', () async {
-      final generator = ColorFileGenerator(tokens: variableTokens.colorTokens);
+      final generator = ColorFileGenerator(
+        tokens: variableTokens.colorTokens,
+        implementsSettings: [],
+      );
 
       final result = formatter.format(
         generator.generate().accept(emitter).toString(),

--- a/website/src/content/docs/reference/configuration-options.mdx
+++ b/website/src/content/docs/reference/configuration-options.mdx
@@ -80,6 +80,7 @@ The following sub-options are available:
 
 - `generate`: Whether to generate color tokens of this type. Defaults to `true`.
 - `from`: An array of paths to generate color tokens from.
+- `implements`: A list of interfaces for specific collections to implement. See the [Implementing Interfaces](/reference/implementing-interfaces) documentation for more information.
 
 See the [Filtering generated Tokens](#filtering-generated-tokens) section for more information.
 
@@ -89,6 +90,7 @@ The following sub-options are available:
 
 - `generate`: Whether to generate typography tokens of this type. Defaults to `true`.
 - `from`: An array of paths to generate typography tokens from.
+- `implements`: A list of interfaces for specific collections to implement. See the [Implementing Interfaces](/reference/implementing-interfaces) documentation for more information.
 - `useGoogleFonts`: Whether to use Google Fonts for font families. Defaults to `true`.
 
 See the [Filtering generated Tokens](#filtering-generated-tokens) section for more information.
@@ -109,6 +111,7 @@ All three options have the following sub-options:
 
 - `generate`: Whether to generate tokens of this type. Defaults to `false`.
 - `from`: An array of paths to generate tokens from.
+- `implements`: A list of interfaces for specific collections to implement. See the [Implementing Interfaces](/reference/implementing-interfaces) documentation for more information.
 
 See the [Filtering generated Tokens](#filtering-generated-tokens) section for more information.
 
@@ -220,6 +223,11 @@ colors:
   generate: true # default
   from:
     - "semantic/colors"
+  implements:
+    - collections: ["semantic"]
+      interfaces:
+      - name: "MyColors"
+        import: "package:my_package/my_colors.dart"
 typography:
   generate: true # default
   from:

--- a/website/src/content/docs/reference/implementing-interfaces.mdx
+++ b/website/src/content/docs/reference/implementing-interfaces.mdx
@@ -1,0 +1,69 @@
+---
+title: Implementing Interfaces
+description: How to extend generated theme classes with your own interfaces for design tokens.
+---
+
+## Implementing Interfaces
+
+You can extend the generated theme classes with your own interfaces to provide additional structure, type safety, or shared APIs for your design tokens. This is especially useful when you want to enforce a contract for your color, typography, or other token collections, or when you want to share implementations across multiple collections.
+
+### How to Use
+
+In your configuration (YAML or Dart map), use the `implements` key under a token type (e.g., `colors`, `typography`). Each entry in `implements` can specify which collections it applies to and a list of interfaces to implement.
+
+#### Example YAML
+
+```yaml
+colors:
+  generate: true
+  implements:
+    - collections: ["semantic", "primitive"] # Will apply to both collections
+      interfaces:
+        - name: "MyColors"
+          import: "package:my_package/my_colors.dart"
+    - collections: [] # Applies to all collections
+      interfaces:
+        - name: "Tokens"
+          import: "package:my_package/tokens.dart"
+```
+
+- `collections`: List of collection names this interface applies to. An empty list means it applies to all collections.
+- `interfaces`: List of interfaces to implement, each witch a `name` and an `import` path.
+
+### What Gets Generated
+
+For each collection, the generator will:
+
+- Add the specified interfaces to the generated class.
+- Add the necessary import statements.
+- If multiple interfaces are specified, all will be implemented.
+
+#### Example Output
+
+```dart
+import 'my_colors.dart';
+import 'tokens.dart';
+
+@immutable
+class ColorsCollection1 extends ThemeExtension<ColorsCollection1>
+    implements MyColors, Tokens {
+  // ...existing code...
+}
+```
+
+### Notes
+
+- If you specify an empty `collections` list, the interface(s) will be applied to all collections of that type.
+- You can implement multiple interfaces per collection.
+- The generator ensures that the correct interfaces are applied to the correct collections, and that imports are included.
+
+### Test Coverage
+
+See the following test files for usage and expected output:
+- `test/src/data/generators/file_generators/color_file_generator_test.dart`
+- `test/src/data/generators/theme_extension_generators/color_theme_extension_generator_test.dart`
+- `test/src/domain/models/config/config_test.dart`
+
+---
+
+This approach allows you to integrate your own interfaces into the generated theme classes, making your design token system more flexible and type-safe.


### PR DESCRIPTION
## Description

Closes #191 

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] My PR title is in the style of [conventional commits](https://www.conventionalcommits.org/)
- [x] All public facing APIs are documented with [dartdoc](https://dart.dev/guides/language/effective-dart/documentation)
- [x] I have added tests to cover my changes
